### PR TITLE
heatmap caching towards #88

### DIFF
--- a/api_handlers.py
+++ b/api_handlers.py
@@ -2,7 +2,7 @@ import webapp2
 import traceback
 import cgi
 
-from lib_db import ImageObject, Picks, Vote, Comment, History
+from lib_db import ImageObject, Picks, Vote, Comment, History, Heatmap
 
 from constants import db_parent
 
@@ -364,6 +364,11 @@ class PickHandler(webapp2.RequestHandler):
                         parent=img_obj)
         history.put()
         
+        cached_heatmap = Heatmap.all().ancestor(img_obj).get()
+        if (cached_heatmap):
+            cached_heatmap.stale = True
+            cached_heatmap.put()
+
         img_obj.put()
 
         self.response.write("Ok")

--- a/lib_db.py
+++ b/lib_db.py
@@ -84,7 +84,8 @@ class Picks(db.Model):
             total += vote.value
 
         return total
-        
+
+
 class History(db.Model):
     user_id = db.StringProperty()
     date = db.DateTimeProperty(auto_now_add=True)
@@ -105,6 +106,9 @@ class Comment(db.Model):
                                  self.user_id).get()
         return user.nickname
     
+class Heatmap(db.Model):
+    stale = db.BooleanProperty(default=False)
+    png = db.BlobProperty()
 
 class ImageObject(db.Model):
 

--- a/pickthis.py
+++ b/pickthis.py
@@ -2,7 +2,7 @@
 import numpy as np
 import StringIO, json, base64
 
-from lib_db import Picks, ImageObject, User, Vote
+from lib_db import Picks, ImageObject, User, Vote, Heatmap
 
 from google.appengine.api import images
 from google.appengine.ext import blobstore
@@ -43,21 +43,9 @@ def normalize(a, newmax):
     return (float(newmax) * a) / np.amax(a)
 
 
-def get_result_image(img_obj, opacity_scalar=None):
-    """
-    Takes an image, gets its interpretations, and makes a
-    new image that shows all the interpretations concatenated.
-    Maps a 'heatmap' colourbar to the result.
-
-    Returns the new 'heatmap' image,
-    plus a count of interpretations.
-
-    """
-    # Read the interpretations for this image.
-    data = Picks.all().ancestor(img_obj).fetch(10000)
-
-    # Get the dimensions.
-    w, h = img_obj.width, img_obj.height
+def generate_heatmap(img_obj, data, opacity_scalar):
+    w = img_obj.width
+    h = img_obj.height
     avg = (w + h) / 2.
 
     # Make an 'empty' image for all the results.
@@ -164,12 +152,36 @@ def get_result_image(img_obj, opacity_scalar=None):
     # Make the 4-channel image from an array.
     im = np.dstack([r, g, b, a])
     im_out = Image.fromarray(im.astype('uint8'), 'RGBA')
+    
+    return im_out
 
-    # Save out into file-like.
-    output = StringIO.StringIO()
-    im_out.save(output, 'png')
 
-    return base64.b64encode(output.getvalue())
+
+def get_result_image(img_obj, opacity_scalar=None):
+    """
+    Takes an image, gets its interpretations, and makes a
+    new image that shows all the interpretations concatenated.
+    Maps a 'heatmap' colourbar to the result.
+
+    Returns the new 'heatmap' image,
+    plus a count of interpretations.
+
+    """
+    # Read the interpretations for this image.
+    data = Picks.all().ancestor(img_obj).fetch(10000)
+
+    cached_heatmap = Heatmap.all().ancestor(img_obj).get()
+
+    if not cached_heatmap or cached_heatmap.stale:
+        print "regenerating heatmap"
+        im_out = generate_heatmap(img_obj, data, opacity_scalar)
+        output = StringIO.StringIO()
+        im_out.save(output, 'png')
+        cached_heatmap = Heatmap(stale=False, png=output.getvalue(), parent=img_obj)
+        cached_heatmap.put()
+
+    print "returning"
+    return base64.b64encode(cached_heatmap.png)
 
 
 def statistics():

--- a/pickthis.py
+++ b/pickthis.py
@@ -173,14 +173,12 @@ def get_result_image(img_obj, opacity_scalar=None):
     cached_heatmap = Heatmap.all().ancestor(img_obj).get()
 
     if not cached_heatmap or cached_heatmap.stale:
-        print "regenerating heatmap"
         im_out = generate_heatmap(img_obj, data, opacity_scalar)
         output = StringIO.StringIO()
         im_out.save(output, 'png')
         cached_heatmap = Heatmap(stale=False, png=output.getvalue(), parent=img_obj)
         cached_heatmap.put()
 
-    print "returning"
     return base64.b64encode(cached_heatmap.png)
 
 


### PR DESCRIPTION
Disclaimers first. 
 - there has been very little testing (needs more), but seems to be working
 - i've chucked the heatmap into a model, which doesn't seem right long term but as the feeling is to move this to the front end anyways, then this is maybe ok as a temporary measure, they can always be cleaned out of the db later
 - maybe there is something i've missed that is bad about doing it like this!?

Initial local tests with just a few interpretations, it seems quicker though :) basically we serve the cached version until its marked as stale in the pickHandler.
